### PR TITLE
Increase `minSdk` to 26

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
     compileSdk 35
     namespace "ai.elimu.startguide"
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 26
         targetSdkVersion 35
         versionCode 2000003
         versionName "2.0.3-SNAPSHOT"

--- a/handgesture/build.gradle
+++ b/handgesture/build.gradle
@@ -8,7 +8,7 @@ android {
     namespace "ai.elimu.handgesture"
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 26
         targetSdkVersion 35
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Increase `minSdk` to 26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the minimum supported Android version to 8.0 (SDK 26) for the app and hand gesture library modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->